### PR TITLE
Add verbose mode (-v/--verbose) support to argument parsing and main …

### DIFF
--- a/include/pscan.h
+++ b/include/pscan.h
@@ -204,7 +204,8 @@ int	print_port_status(char *, PStatus, char *);
 void	print_response_packets(struct tcphdr*, struct icmphdr*, int);
 void      print_line(char, int, char *, char *, bool);
 
-char		*itoa(char*, size_t, int, bool);
+//char		*itoa(char*, size_t, int, bool);
+char *itoa(char *s, size_t s_s, int n, bool t);
 void		exit_call(char*, int);
 unsigned short 	csum(unsigned short*, int);
 char		*_interface_ip(char *, int);

--- a/src/parsing.c
+++ b/src/parsing.c
@@ -230,7 +230,7 @@ void	parse_input(Options *input, char **v, int c) {
 	if (c > 3) {
 		int	arg = 1;
 		for (; arg < c - 2;) {
-			if (!strcmp(v[arg], "--verbose")) {
+			if (!strcmp(v[arg], "--verbose") || !strcmp(v[arg], "-v")) {
 				input->verbose = 1;
 				arg++;
 			}


### PR DESCRIPTION
this change adds support for the -v and --verbose command-line flags.
When either flag is specified, the port scanner prints detailed output for each scanned port, indicating whether it is open or closed. no changes are made to the existing scan logic unless the verbose flag is used.
This feature helps users see scan progress in real time and is useful for debugging.